### PR TITLE
fmt.key bug

### DIFF
--- a/R/plot.matrix.R
+++ b/R/plot.matrix.R
@@ -191,6 +191,14 @@ plot.matrix <- function(x, y=x, breaks=NULL, col=heat.colors, na.col="white",
     if (!is.na(digits)) {
       if (matrixtype==1) fmt.key <- if (digits<0) sprintf("%%+.%.0fe", -digits) else sprintf("%%+.%.0ff", digits)
       if (matrixtype==2) fmt.key <- if (digits<0) sprintf("%%+.%.0fs", -digits) else sprintf("%%+.%.0fs", digits)
+    } else {
+      if (matrixtype==1) {
+        digits  <- as.integer(2-log10(diff(breaks)[1])) 
+        fmt.key <- if (digits<0) sprintf("%%+.%.0fe", -digits) else sprintf("%%+.%.0ff", digits)
+      }
+      if (matrixtype==2) {   
+        fmt.key <- "%s"
+      }
     }
   }
   ## shall we plot the key?
@@ -199,15 +207,6 @@ plot.matrix <- function(x, y=x, breaks=NULL, col=heat.colors, na.col="white",
       if (is.null(axis.key)) {
         axis.key <- if (is.null(key)) list() else key
         if (is.null(axis.key$side)) axis.key$side <- 4
-      }
-      if (is.null(fmt.key)) {
-        if (matrixtype==1) {
-          digits  <- as.integer(2-log10(diff(breaks)[1])) 
-          fmt.key <- if (digits<0) sprintf("%%+.%.0fe", -digits) else sprintf("%%+.%.0ff", digits)
-        }
-        if (matrixtype==2) {   
-          fmt.key <- "%s"
-        }
       }
     } 
   }


### PR DESCRIPTION
Dear Sigbert,

After modifying behavior of `key=NULL`, I encountered a bug when plotting a matrix with default parameters (my bad to not have tested this in the first place).

Here is a reproducible example with the current version of the package in the repository:
```R
plot(x)
# Error in sprintf(fmt.key, breaks) : 'fmt' is not a character vector
```

This error comes from the fact that a default value for `fmt.key` is not set anymore when not plotting the key. By separating the test for `key` from the other tests now done on line 198, these tests are always `FALSE` by default and `fmt.key` keeps is `NULL` value. I moved the block that sets the `fmt.key` default value in the `fmt.key` test block. This has resolved the problem in all cases I was able to test.

Fred
