### PR TITLE
New arguments related to NA values

### DIFF
--- a/man/plot.matrix.Rd
+++ b/man/plot.matrix.Rd
@@ -6,10 +6,11 @@
 \title{plot.matrix}
 \usage{
 \method{plot}{matrix}(x, y = NULL, breaks = NULL, col = heat.colors,
-  na.col = "white", digits = NA, fmt.cell = NULL, fmt.key = NULL,
-  polygon.cell = NULL, polygon.key = NULL, text.cell = NULL,
-  key = list(side = 4, las = 1), axis.col = list(side = 1),
-  axis.row = list(side = 2), axis.key = NULL, max.col = 70, ...)
+  na.col = "white", na.cell = TRUE, na.print = TRUE, digits = NA,
+  fmt.cell = NULL, fmt.key = NULL, polygon.cell = NULL,
+  polygon.key = NULL, text.cell = NULL, key = list(side = 4, las =
+  1), axis.col = list(side = 1), axis.row = list(side = 2),
+  axis.key = NULL, max.col = 70, ...)
 }
 \arguments{
 \item{x}{matrix}
@@ -21,6 +22,10 @@
 \item{col}{a vector of colors or a function, e.g. \code{\link[grDevices]{heat.colors}} with one parameter \code{n}}
 
 \item{na.col}{color for missing value (default: white)}
+
+\item{na.cell}{draw cells with missing values}
+
+\item{na.print}{print NA (or any given characters) when values are missing. If \code{FALSE}, nothing is printed. If \code{na.cell} is \code{FALSE}, this will have no effect.}
 
 \item{digits}{number of digits for numeric data or length of string for non-numeric data}
 
@@ -141,4 +146,9 @@ plot(unclass(tab))
 cst <- chisq.test(apply(HairEyeColor, 1:2, sum))
 col <- colorRampPalette(c("blue", "white", "red"))
 plot(cst$residuals, col=col, breaks=c(-7.5,7.5))
+# triangular matrix
+x[upper.tri(x)] <- NA
+plot(x, digit=2)
+plot(x, na.print=FALSE)
+plot(x, na.cell=FALSE)
 }


### PR DESCRIPTION
Dear Sigbert,

I have been working on adding new arguments to the `plot.matrix` function regarding NA cells. I needed to plot a triangular matrix without printing the NA values (see the panel B of [this figure](https://www.biorxiv.org/content/biorxiv/early/2019/08/20/657056/F3.large.jpg?width=800&height=600&carousel=1)). Basically, I added two new arguments:
* `na.cell` to print (or not) cells with NA,
*  `na.print` to replace the NA value with a given value.

I tested the edited function with number, character and logical matrices.

I hope this is of interest. Feel free to modify it if needed.

Fred